### PR TITLE
Fix 'undo' (bug introduced in levels update)

### DIFF
--- a/pinball.js
+++ b/pinball.js
@@ -801,7 +801,9 @@ function press(evt){
   } else if (evt.keyCode===90){//z
     if (undoList.length>0){
       var dat = undoList.pop();
-      masterCanvas=dat.canvasDat;
+      for(var i = 0; i < dat.canvasDat.length; i ++){
+        masterCanvas[i] = dat.canvasDat[i];
+      }
       compile();
       setVisuals(true);
       if (shareLinkInner!=null){


### PR DESCRIPTION
undo would replace masterCanavs, instead of copying into the current masterCanavs
